### PR TITLE
[SubMob/LogMob#292] Enable parallel Gradle sync

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -35,3 +35,6 @@ POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/SubMob/LogMob.git
 # Publish to the new Central Portal and auto-release (no manual "release" step)
 SONATYPE_HOST=CENTRAL_PORTAL
 SONATYPE_AUTOMATIC_RELEASE=true
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true


### PR DESCRIPTION
Enables parallel Gradle model building during IDE sync (Gradle 9.4+), speeding up sync for this multi-module project.

Closes #292